### PR TITLE
Use Quasar body classes for theme color variables

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -23,6 +23,10 @@
 
 /* semantic color variables for this project */
 :root {
+  --section-gap: 160px;
+}
+
+body.body--light {
   --color-background: var(--vt-c-white);
   --color-background-soft: var(--vt-c-white-soft);
   --color-background-mute: var(--vt-c-white-mute);
@@ -32,22 +36,18 @@
 
   --color-heading: var(--vt-c-text-light-1);
   --color-text: var(--vt-c-text-light-1);
-
-  --section-gap: 160px;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-background: var(--vt-c-black);
-    --color-background-soft: var(--vt-c-black-soft);
-    --color-background-mute: var(--vt-c-black-mute);
+body.body--dark {
+  --color-background: var(--vt-c-black);
+  --color-background-soft: var(--vt-c-black-soft);
+  --color-background-mute: var(--vt-c-black-mute);
 
-    --color-border: var(--vt-c-divider-dark-2);
-    --color-border-hover: var(--vt-c-divider-dark-1);
+  --color-border: var(--vt-c-divider-dark-2);
+  --color-border-hover: var(--vt-c-divider-dark-1);
 
-    --color-heading: var(--vt-c-text-dark-1);
-    --color-text: var(--vt-c-text-dark-2);
-  }
+  --color-heading: var(--vt-c-text-dark-1);
+  --color-text: var(--vt-c-text-dark-2);
 }
 
 *,


### PR DESCRIPTION
## Summary
- define semantic color variables on Quasar body theme classes instead of prefers-color-scheme media query
- keep body background referencing the theme variable so Dark.set updates the background

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc326512f0832886a015c290a602e6